### PR TITLE
fix: `Many::toBuildFrom` return type does not match with the someToBuildFromFunction

### DIFF
--- a/src/Many.php
+++ b/src/Many.php
@@ -27,10 +27,11 @@ final class Many
 
     /**
      * @template T
+     * @template TBuilder of Buildatable<T>
      *
-     * @param class-string<Buildatable<T>> $class
+     * @param class-string<TBuilder> $class
      *
-     * @return array<Buildatable<T>>
+     * @return array<TBuilder>
      */
     public static function toBuildFrom(string $class, int|null $numberOfItems = null): array
     {


### PR DESCRIPTION
fix https://github.com/buildotter/php-core/issues/53